### PR TITLE
feat: enforce invite sender ownership and settlement integrity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,15 @@
 - `feature_finalize [next-issue-number]`:
   1. Run `feature_commit`.
   2. Detect current branch name.
-  3. Update remote `develop` from remote current branch with fast-forward only:
-     - Use `git push origin origin/<current-branch>:develop` only if safe (fast-forward).
-  4. If `[next-issue-number]` is provided, run `feature_start <next-issue-number>` to create and checkout the next branch; otherwise skip this step.
+  3. Create a PR from `<current-branch>` into `develop` (do not push directly to `develop`).
+  4. In the PR description, include:
+     - a concise summary of the implemented changes,
+     - files/modules affected,
+     - test/validation results,
+     - issue-closing keyword when applicable (for example: `Closes #<issue-number>`).
+  5. Share the PR link and change summary for review before merge.
+  6. Merge the PR into `develop` after review/approval and required checks pass.
+  7. If `[next-issue-number]` is provided, run `feature_start <next-issue-number>` to create and checkout the next branch; otherwise skip this step.
 
 ## Issue Linking Rules
 - Linking commits/PRs to issues does not require a GitHub Action workflow by default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,14 +37,19 @@
   1. Run `feature_commit`.
   2. Detect current branch name.
   3. Create a PR from `<current-branch>` into `develop` (do not push directly to `develop`).
-  4. In the PR description, include:
+  4. Name the PR title using conventional-commit style so CI title validation passes:
+     - use `<type>: #<issue-number> <concise-summary>` when issue number is available.
+     - use `<type>: <concise-summary>` when issue number is not available.
+     - valid `<type>` values: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`, `build`, `revert`.
+     - map branch prefixes by default: `feature -> feat`, `bugfix -> fix`, `hotfix -> fix`, `chore -> chore`.
+  5. In the PR description, include:
      - a concise summary of the implemented changes,
      - files/modules affected,
      - test/validation results,
      - issue-closing keyword when applicable (for example: `Closes #<issue-number>`).
-  5. Share the PR link and change summary for review before merge.
-  6. Merge the PR into `develop` after review/approval and required checks pass.
-  7. If `[next-issue-number]` is provided, run `feature_start <next-issue-number>` to create and checkout the next branch; otherwise skip this step.
+  6. Share the PR link and change summary for review before merge.
+  7. Merge the PR into `develop` after review/approval and required checks pass.
+  8. If `[next-issue-number]` is provided, run `feature_start <next-issue-number>` to create and checkout the next branch; otherwise skip this step.
 
 ## Issue Linking Rules
 - Linking commits/PRs to issues does not require a GitHub Action workflow by default.
@@ -52,6 +57,7 @@
 - GitHub automatically links when commit bodies or PR descriptions include references like `#123`.
 - GitHub automatically closes issues when PR descriptions include keywords such as `Closes #123`, `Fixes #123`, or `Resolves #123` and the PR is merged into the default branch.
 - If strict enforcement is needed, add a separate workflow or branch rule that fails PRs missing required issue references.
+- Labels can be used for triage/automation, but labels do not replace required PR title conventions or issue references.
 
 ## Branch Strategy and Protection
 - Every repository should use a two-base-branch model:
@@ -205,3 +211,4 @@ Why the correct approach works:
 - `Select-Object -First N` safely reads the first N lines.
 - `Select-Object -Skip N -First M` safely reads specific line ranges.
 - No directory navigation is needed; direct file access is simpler and more reliable.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,7 @@
      - test/validation results,
      - issue-closing keyword when applicable (for example: `Closes #<issue-number>`).
   6. Share the PR link and change summary for review before merge.
-  7. Merge the PR into `develop` after review/approval and required checks pass.
-  8. If `[next-issue-number]` is provided, run `feature_start <next-issue-number>` to create and checkout the next branch; otherwise skip this step.
+  7. If `[next-issue-number]` is provided, run `feature_start <next-issue-number>` to create and checkout the next branch; otherwise skip this step.
 
 ## Issue Linking Rules
 - Linking commits/PRs to issues does not require a GitHub Action workflow by default.

--- a/src/MambaSplit.Api/Controllers/GroupController.cs
+++ b/src/MambaSplit.Api/Controllers/GroupController.cs
@@ -52,15 +52,33 @@ public class GroupController : ControllerBase
     public async Task<ActionResult<InviteDto>> Invite(string groupId, [FromBody] InviteRequest request, CancellationToken ct)
     {
         var gid = ParseGuid(groupId, "groupId");
-        await _groupService.RequireMemberAsync(gid, User.UserId(), ct);
-        var invite = await _groupService.CreateInviteAsync(gid, request.Email, ct);
-        return Ok(new InviteDto(invite.Token, invite.Email, invite.ExpiresAt.ToString("O")));
+        var actorUserId = User.UserId();
+        await _groupService.RequireMemberAsync(gid, actorUserId, ct);
+        var invite = await _groupService.CreateInviteAsync(gid, request.Email, actorUserId, ct);
+        return Ok(new InviteDto(
+            invite.Token,
+            invite.SentByUserId.ToString(),
+            invite.SentToEmail,
+            invite.Email,
+            invite.ExpiresAt.ToString("O")));
     }
 
+    // Legacy endpoint retained for backward compatibility; current clients should use cancel-by-id.
     [HttpDelete("{groupId}/invites/{token}")]
     public async Task<IActionResult> CancelInvite(string groupId, string token, CancellationToken ct)
     {
         await _groupService.CancelInviteAsync(ParseGuid(groupId, "groupId"), token, User.UserId(), ct);
+        return NoContent();
+    }
+
+    [HttpDelete("{groupId}/invites/by-id/{inviteId}")]
+    public async Task<IActionResult> CancelInviteById(string groupId, string inviteId, CancellationToken ct)
+    {
+        await _groupService.CancelInviteByIdAsync(
+            ParseGuid(groupId, "groupId"),
+            ParseGuid(inviteId, "inviteId"),
+            User.UserId(),
+            ct);
         return NoContent();
     }
 
@@ -89,12 +107,21 @@ public record GroupDto(string Id, string Name)
 }
 
 public record InviteRequest([Required, NotBlank, EmailAddress, MaxLength(320)] string Email);
-public record InviteDto(string Token, string Email, string ExpiresAt);
-public record GroupInviteDto(string Id, string GroupId, string Email, string ExpiresAt, string CreatedAt)
+public record InviteDto(string Token, string SentByUserId, string SentToEmail, string Email, string ExpiresAt);
+public record GroupInviteDto(
+    string Id,
+    string GroupId,
+    string SentByUserId,
+    string SentToEmail,
+    string Email,
+    string ExpiresAt,
+    string CreatedAt)
 {
     public static GroupInviteDto From(GroupService.GroupInvite invite) => new(
         invite.Id.ToString(),
         invite.GroupId.ToString(),
+        invite.SentByUserId.ToString(),
+        invite.SentToEmail,
         invite.Email,
         invite.ExpiresAt.ToString("O"),
         invite.CreatedAt.ToString("O"));

--- a/src/MambaSplit.Api/Data/AppDbContext.cs
+++ b/src/MambaSplit.Api/Data/AppDbContext.cs
@@ -41,6 +41,15 @@ public class AppDbContext : DbContext
             .HasIndex(x => x.TokenHash)
             .IsUnique();
 
+        modelBuilder.Entity<InviteEntity>()
+            .HasIndex(x => new { x.GroupId, x.SentByUserId, x.CreatedAt });
+
+        modelBuilder.Entity<InviteEntity>()
+            .HasOne<UserEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.SentByUserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         modelBuilder.Entity<ExpenseSplitEntity>()
             .HasIndex(x => new { x.ExpenseId, x.UserId })
             .IsUnique();

--- a/src/MambaSplit.Api/Database/Migrations/V6__invite_sender_ownership.sql
+++ b/src/MambaSplit.Api/Database/Migrations/V6__invite_sender_ownership.sql
@@ -1,0 +1,40 @@
+ALTER TABLE invites
+    ADD COLUMN IF NOT EXISTS sent_by_user_id uuid;
+
+UPDATE invites i
+SET sent_by_user_id = g.created_by
+FROM groups g
+WHERE i.group_id = g.id
+  AND i.sent_by_user_id IS NULL;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM invites
+        WHERE sent_by_user_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'Unable to backfill invites.sent_by_user_id for one or more rows.';
+    END IF;
+END $$;
+
+ALTER TABLE invites
+    ALTER COLUMN sent_by_user_id SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_invites_users_sent_by_user_id'
+    ) THEN
+        ALTER TABLE invites
+            ADD CONSTRAINT fk_invites_users_sent_by_user_id
+                FOREIGN KEY (sent_by_user_id) REFERENCES users (id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_invites_group_sender_created_desc
+    ON invites (group_id, sent_by_user_id, created_at DESC);
+
+DROP TABLE IF EXISTS public.flyway_schema_history;

--- a/src/MambaSplit.Api/Database/Migrations/V7__enforce_settlement_expense_link.sql
+++ b/src/MambaSplit.Api/Database/Migrations/V7__enforce_settlement_expense_link.sql
@@ -1,0 +1,63 @@
+CREATE OR REPLACE FUNCTION check_settlement_has_expense_link()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    settlement_id_to_check uuid;
+BEGIN
+    IF TG_TABLE_NAME = 'settlements' THEN
+        settlement_id_to_check := NEW.id;
+    ELSE
+        settlement_id_to_check := COALESCE(NEW.settlement_id, OLD.settlement_id);
+    END IF;
+
+    IF settlement_id_to_check IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM settlements s
+        WHERE s.id = settlement_id_to_check
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM settlement_expenses se
+        WHERE se.settlement_id = settlement_id_to_check
+    ) THEN
+        RAISE EXCEPTION 'Settlement % must link at least one expense', settlement_id_to_check
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'ctrg_settlement_requires_expense_link_on_settlement'
+    ) THEN
+        CREATE CONSTRAINT TRIGGER ctrg_settlement_requires_expense_link_on_settlement
+            AFTER INSERT OR UPDATE ON settlements
+            DEFERRABLE INITIALLY DEFERRED
+            FOR EACH ROW
+            EXECUTE FUNCTION check_settlement_has_expense_link();
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'ctrg_settlement_requires_expense_link_on_settlement_expense'
+    ) THEN
+        CREATE CONSTRAINT TRIGGER ctrg_settlement_requires_expense_link_on_settlement_expense
+            AFTER UPDATE OF settlement_id OR DELETE ON settlement_expenses
+            DEFERRABLE INITIALLY DEFERRED
+            FOR EACH ROW
+            EXECUTE FUNCTION check_settlement_has_expense_link();
+    END IF;
+END $$;

--- a/src/MambaSplit.Api/Domain/InviteEntity.cs
+++ b/src/MambaSplit.Api/Domain/InviteEntity.cs
@@ -13,9 +13,19 @@ public class InviteEntity
     [Column("group_id")]
     public Guid GroupId { get; set; }
 
+    [Column("sent_by_user_id")]
+    public Guid SentByUserId { get; set; }
+
     [Column("email")]
     [MaxLength(320)]
-    public string Email { get; set; } = string.Empty;
+    public string SentToEmail { get; set; } = string.Empty;
+
+    [NotMapped]
+    public string Email
+    {
+        get => SentToEmail;
+        set => SentToEmail = value;
+    }
 
     [Column("token_hash")]
     [MaxLength(120)]

--- a/src/MambaSplit.Api/Services/GroupService.cs
+++ b/src/MambaSplit.Api/Services/GroupService.cs
@@ -288,13 +288,13 @@ public class GroupService
         var pending = await (
             from i in _db.Invites
             join g in _db.Groups on i.GroupId equals g.Id
-            where i.Email.ToLower() == normalizedQueryEmail && i.ExpiresAt > now
+            where i.SentToEmail.ToLower() == normalizedQueryEmail && i.ExpiresAt > now
             orderby i.CreatedAt descending
             select new PendingInvite(
                 i.Id,
                 i.GroupId,
                 g.Name,
-                i.Email.ToLower(),
+                i.SentToEmail.ToLower(),
                 i.ExpiresAt,
                 i.CreatedAt))
             .ToListAsync(ct);
@@ -302,7 +302,11 @@ public class GroupService
         return pending;
     }
 
-    public async Task<CreatedInvite> CreateInviteAsync(Guid groupId, string email, CancellationToken ct = default)
+    public async Task<CreatedInvite> CreateInviteAsync(
+        Guid groupId,
+        string email,
+        Guid actorUserId,
+        CancellationToken ct = default)
     {
         var normalizedEmail = NormalizeInviteEmail(email);
 
@@ -319,7 +323,7 @@ public class GroupService
 
         var now = DateTimeOffset.UtcNow;
         var existingInvite = await _db.Invites
-            .FirstOrDefaultAsync(i => i.GroupId == groupId && i.Email.ToLower() == normalizedEmail, ct);
+            .FirstOrDefaultAsync(i => i.GroupId == groupId && i.SentToEmail.ToLower() == normalizedEmail, ct);
 
         if (existingInvite is not null)
         {
@@ -339,25 +343,37 @@ public class GroupService
         {
             Id = Guid.NewGuid(),
             GroupId = groupId,
-            Email = normalizedEmail,
+            SentByUserId = actorUserId,
+            SentToEmail = normalizedEmail,
             TokenHash = tokenHash,
             ExpiresAt = expiresAt,
             CreatedAt = now,
         });
 
         await _db.SaveChangesAsync(ct);
-        return new CreatedInvite(token, normalizedEmail, expiresAt);
+        return new CreatedInvite(token, actorUserId, normalizedEmail, normalizedEmail, expiresAt);
     }
 
     public async Task<List<GroupInvite>> ListGroupInvitesAsync(Guid groupId, Guid actorUserId, CancellationToken ct = default)
     {
         await RequireMemberAsync(groupId, actorUserId, ct);
         var now = DateTimeOffset.UtcNow;
-        return await _db.Invites
-            .Where(i => i.GroupId == groupId && i.ExpiresAt > now)
-            .OrderByDescending(i => i.CreatedAt)
-            .Select(i => new GroupInvite(i.Id, i.GroupId, i.Email.ToLower(), i.ExpiresAt, i.CreatedAt))
+        var invites = await _db.Invites
+            .Where(i => i.GroupId == groupId && i.SentByUserId == actorUserId)
             .ToListAsync(ct);
+
+        return invites
+            .Where(i => i.ExpiresAt > now)
+            .OrderByDescending(i => i.CreatedAt)
+            .Select(i => new GroupInvite(
+                i.Id,
+                i.GroupId,
+                i.SentByUserId,
+                i.SentToEmail.ToLower(),
+                i.SentToEmail.ToLower(),
+                i.ExpiresAt,
+                i.CreatedAt))
+            .ToList();
     }
 
     public async Task CancelInviteAsync(Guid groupId, string rawToken, Guid actorUserId, CancellationToken ct = default)
@@ -369,13 +385,44 @@ public class GroupService
         }
 
         var tokenHash = TokenCodec.Sha256Base64Url(rawToken);
-        var deleted = await _db.Database.ExecuteSqlInterpolatedAsync(
-            $@"delete from invites where group_id = {groupId} and token_hash = {tokenHash}",
-            ct);
-        if (deleted == 0)
+        var invite = await _db.Invites
+            .FirstOrDefaultAsync(i => i.GroupId == groupId && i.TokenHash == tokenHash, ct);
+        if (invite is null)
         {
             throw new ResourceNotFoundException("Invite", "token hash");
         }
+
+        if (invite.SentByUserId != actorUserId)
+        {
+            throw new AuthorizationException("cancel", $"invite {invite.Id}");
+        }
+
+        _db.Invites.Remove(invite);
+        await _db.SaveChangesAsync(ct);
+    }
+
+    public async Task CancelInviteByIdAsync(Guid groupId, Guid inviteId, Guid actorUserId, CancellationToken ct = default)
+    {
+        await RequireMemberAsync(groupId, actorUserId, ct);
+
+        var invite = await _db.Invites.FindAsync(new object[] { inviteId }, ct);
+        if (invite is null)
+        {
+            throw new ResourceNotFoundException("Invite", inviteId.ToString());
+        }
+
+        if (invite.GroupId != groupId)
+        {
+            throw new ResourceNotFoundException("Invite", inviteId.ToString());
+        }
+
+        if (invite.SentByUserId != actorUserId)
+        {
+            throw new AuthorizationException("cancel", $"invite {invite.Id}");
+        }
+
+        _db.Invites.Remove(invite);
+        await _db.SaveChangesAsync(ct);
     }
 
     public async Task AcceptInviteAsync(string rawToken, Guid userId, CancellationToken ct = default)
@@ -398,7 +445,7 @@ public class GroupService
             throw new ResourceNotFoundException("User", userId.ToString());
         }
 
-        if (!string.Equals(invite.Email, user.Email, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(invite.SentToEmail, user.Email, StringComparison.OrdinalIgnoreCase))
         {
             throw new ValidationException("Invite email does not match authenticated user");
         }
@@ -445,7 +492,7 @@ public class GroupService
             throw new ResourceNotFoundException("User", userId.ToString());
         }
 
-        if (!string.Equals(invite.Email, user.Email, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(invite.SentToEmail, user.Email, StringComparison.OrdinalIgnoreCase))
         {
             throw new ValidationException("Invite email does not match authenticated user");
         }
@@ -571,8 +618,20 @@ public class GroupService
         return suggestions;
     }
 
-    public record CreatedInvite(string Token, string Email, DateTimeOffset ExpiresAt);
-    public record GroupInvite(Guid Id, Guid GroupId, string Email, DateTimeOffset ExpiresAt, DateTimeOffset CreatedAt);
+    public record CreatedInvite(
+        string Token,
+        Guid SentByUserId,
+        string SentToEmail,
+        string Email,
+        DateTimeOffset ExpiresAt);
+    public record GroupInvite(
+        Guid Id,
+        Guid GroupId,
+        Guid SentByUserId,
+        string SentToEmail,
+        string Email,
+        DateTimeOffset ExpiresAt,
+        DateTimeOffset CreatedAt);
     public record PendingInvite(Guid Id, Guid GroupId, string GroupName, string Email, DateTimeOffset ExpiresAt, DateTimeOffset CreatedAt);
     public record GroupDetails(
         GroupInfo Group,

--- a/src/MambaSplit.Api/Services/SettlementService.cs
+++ b/src/MambaSplit.Api/Services/SettlementService.cs
@@ -52,6 +52,11 @@ public class SettlementService
             throw new ValidationException("Duplicate expense ids in settlement payload");
         }
 
+        if (normalizedExpenseIds.Count == 0)
+        {
+            throw new ValidationException("At least one expense must be selected");
+        }
+
         await _groupService.RequireMemberAsync(groupId, actorUserId, ct);
         await _groupService.RequireMembersAsync(groupId, new[] { fromUserId, toUserId }, ct);
 
@@ -82,26 +87,58 @@ public class SettlementService
         {
             var expenses = await _db.Expenses
                 .Where(e => e.GroupId == groupId && normalizedExpenseIds.Contains(e.Id))
-                .Select(e => new { e.Id, e.AmountCents })
+                .Select(e => new { e.Id, e.PayerUserId })
                 .ToListAsync(ct);
             if (expenses.Count != normalizedExpenseIds.Count)
             {
                 throw new ValidationException("One or more expenses do not belong to this group");
             }
 
-            long expectedAmountCents;
+            var expenseIdsSet = normalizedExpenseIds.ToHashSet();
+            var splits = await _db.ExpenseSplits
+                .Where(s => expenseIdsSet.Contains(s.ExpenseId) && (s.UserId == fromUserId || s.UserId == toUserId))
+                .Select(s => new { s.ExpenseId, s.UserId, s.AmountOwedCents })
+                .ToListAsync(ct);
+            var splitsByExpense = splits
+                .GroupBy(s => s.ExpenseId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            long expectedAmountCents = 0;
             try
             {
-                expectedAmountCents = expenses.Sum(e => e.AmountCents);
+                foreach (var expense in expenses)
+                {
+                    var expenseSplits = splitsByExpense.GetValueOrDefault(expense.Id, []);
+                    if (expense.PayerUserId == toUserId)
+                    {
+                        var fromOwed = expenseSplits
+                            .Where(s => s.UserId == fromUserId)
+                            .Sum(s => s.AmountOwedCents);
+                        expectedAmountCents = checked(expectedAmountCents + fromOwed);
+                    }
+
+                    if (expense.PayerUserId == fromUserId)
+                    {
+                        var toOwed = expenseSplits
+                            .Where(s => s.UserId == toUserId)
+                            .Sum(s => s.AmountOwedCents);
+                        expectedAmountCents = checked(expectedAmountCents - toOwed);
+                    }
+                }
             }
             catch (OverflowException)
             {
-                throw new ValidationException("Expense amount sum overflow");
+                throw new ValidationException("Settlement amount calculation overflow");
+            }
+
+            if (expectedAmountCents <= 0)
+            {
+                throw new ValidationException("Selected expenses do not produce an outstanding balance for the selected payer and receiver");
             }
 
             if (expectedAmountCents != amountCents)
             {
-                throw new ValidationException($"Settlement amount ({amountCents}) must match selected expense total ({expectedAmountCents})");
+                throw new ValidationException($"Settlement amount ({amountCents}) must match selected outstanding balance ({expectedAmountCents})");
             }
 
             var alreadySettled = await _db.SettlementExpenses
@@ -341,7 +378,8 @@ public class SettlementService
         }
 
         if (pg.SqlState != PostgresErrorCodes.ForeignKeyViolation &&
-            pg.SqlState != PostgresErrorCodes.UniqueViolation)
+            pg.SqlState != PostgresErrorCodes.UniqueViolation &&
+            pg.SqlState != PostgresErrorCodes.CheckViolation)
         {
             return false;
         }

--- a/src/MambaSplit.Api/appsettings.Test.json
+++ b/src/MambaSplit.Api/appsettings.Test.json
@@ -6,12 +6,12 @@
     "security": {
       "jwt": {
         "issuer": "mambasplit-api-test",
-        "secret": "",
+        "secret": "dev-only-jwt-secret-change-me-1234567890",
         "accessTokenMinutes": 15,
         "refreshTokenDays": 30
       },
       "google": {
-        "client-id": ""
+        "client-id": "505213355065-2bupm12mn12g2058edf3givhmu3enqgh.apps.googleusercontent.com"
       }
     }
   },

--- a/src/MambaSplit.Api/appsettings.Test.json
+++ b/src/MambaSplit.Api/appsettings.Test.json
@@ -6,7 +6,7 @@
     "security": {
       "jwt": {
         "issuer": "mambasplit-api-test",
-        "secret": "dev-only-jwt-secret-change-me-1234567890",
+        "secret": "test-secret-change-me-test-secret-change-me",
         "accessTokenMinutes": 15,
         "refreshTokenDays": 30
       },
@@ -16,6 +16,6 @@
     }
   },
   "ConnectionStrings": {
-    "Default": ""
+    "Default": "Host=ignored;Database=ignored;Username=ignored;Password=ignored"
   }
 }

--- a/tests/MambaSplit.Api.Tests/Integration/FlowIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/FlowIntegrationTests.cs
@@ -192,6 +192,188 @@ public class FlowIntegrationTests
     }
 
     [Fact]
+    public async Task GroupInvites_AreScopedToSenderWithinSameGroup()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, userIdA, _) = await Signup(client, "Owner", "password123");
+        var (accessB, _, userIdB, emailB) = await Signup(client, "Member", "password123");
+        var (_, _, _, emailC) = await Signup(client, "Invitee C", "password123");
+        var (_, _, _, emailD) = await Signup(client, "Invitee D", "password123");
+
+        var groupId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "Sender Scope Group" }, accessA)))["id"]!.GetValue<string>();
+        var memberInviteToken = (await ReadJsonObject(await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailB }, accessA)))["token"]!.GetValue<string>();
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = memberInviteToken }, accessB)).StatusCode);
+
+        var inviteByA = await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailC }, accessA);
+        Assert.Equal(HttpStatusCode.OK, inviteByA.StatusCode);
+        var payloadByA = await ReadJsonObject(inviteByA);
+        Assert.Equal(userIdA, payloadByA["sentByUserId"]?.GetValue<string>());
+        Assert.Equal(emailC.ToLowerInvariant(), payloadByA["sentToEmail"]?.GetValue<string>());
+        Assert.Equal(emailC.ToLowerInvariant(), payloadByA["email"]?.GetValue<string>());
+
+        var inviteByB = await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailD }, accessB);
+        Assert.Equal(HttpStatusCode.OK, inviteByB.StatusCode);
+        var payloadByB = await ReadJsonObject(inviteByB);
+        Assert.Equal(userIdB, payloadByB["sentByUserId"]?.GetValue<string>());
+        Assert.Equal(emailD.ToLowerInvariant(), payloadByB["sentToEmail"]?.GetValue<string>());
+        Assert.Equal(emailD.ToLowerInvariant(), payloadByB["email"]?.GetValue<string>());
+
+        var listAResponse = await Get(client, $"/api/v1/groups/{groupId}/invites", accessA);
+        Assert.Equal(HttpStatusCode.OK, listAResponse.StatusCode);
+        var listA = await listAResponse.Content.ReadFromJsonAsync<JsonArray>(JsonOptions) ?? new JsonArray();
+        Assert.Single(listA);
+        Assert.Equal(userIdA, listA[0]?["sentByUserId"]?.GetValue<string>());
+        Assert.Equal(emailC.ToLowerInvariant(), listA[0]?["sentToEmail"]?.GetValue<string>());
+        Assert.Equal(emailC.ToLowerInvariant(), listA[0]?["email"]?.GetValue<string>());
+
+        var listBResponse = await Get(client, $"/api/v1/groups/{groupId}/invites", accessB);
+        Assert.Equal(HttpStatusCode.OK, listBResponse.StatusCode);
+        var listB = await listBResponse.Content.ReadFromJsonAsync<JsonArray>(JsonOptions) ?? new JsonArray();
+        Assert.Single(listB);
+        Assert.Equal(userIdB, listB[0]?["sentByUserId"]?.GetValue<string>());
+        Assert.Equal(emailD.ToLowerInvariant(), listB[0]?["sentToEmail"]?.GetValue<string>());
+        Assert.Equal(emailD.ToLowerInvariant(), listB[0]?["email"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task CancelInvite_OnlySenderCanCancel()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, _, _) = await Signup(client, "Owner", "password123");
+        var (accessB, _, _, emailB) = await Signup(client, "Member", "password123");
+        var (_, _, _, emailC) = await Signup(client, "Invitee C", "password123");
+
+        var groupId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "Cancel Sender Group" }, accessA)))["id"]!.GetValue<string>();
+        var memberInviteToken = (await ReadJsonObject(await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailB }, accessA)))["token"]!.GetValue<string>();
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = memberInviteToken }, accessB)).StatusCode);
+
+        var inviteToken = (await ReadJsonObject(await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailC }, accessA)))["token"]!.GetValue<string>();
+
+        var cancelByNonSender = await Delete(client, $"/api/v1/groups/{groupId}/invites/{inviteToken}", accessB);
+        Assert.Equal(HttpStatusCode.Forbidden, cancelByNonSender.StatusCode);
+
+        var cancelBySender = await Delete(client, $"/api/v1/groups/{groupId}/invites/{inviteToken}", accessA);
+        Assert.Equal(HttpStatusCode.NoContent, cancelBySender.StatusCode);
+    }
+
+    [Fact]
+    public async Task CancelInviteById_SenderCanCancelOwnInvite()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, _, _) = await Signup(client, "Owner", "password123");
+        var (_, _, _, emailC) = await Signup(client, "Invitee C", "password123");
+
+        var groupId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "ById Cancel Group" }, accessA)))["id"]!.GetValue<string>();
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailC }, accessA)).StatusCode);
+
+        var listResponse = await Get(client, $"/api/v1/groups/{groupId}/invites", accessA);
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var invites = await listResponse.Content.ReadFromJsonAsync<JsonArray>(JsonOptions) ?? new JsonArray();
+        var inviteId = invites[0]?["id"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(inviteId));
+
+        var cancel = await Delete(client, $"/api/v1/groups/{groupId}/invites/by-id/{inviteId}", accessA);
+        Assert.Equal(HttpStatusCode.NoContent, cancel.StatusCode);
+    }
+
+    [Fact]
+    public async Task CancelInviteById_NonSenderMemberCannotCancel()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, _, _) = await Signup(client, "Owner", "password123");
+        var (accessB, _, _, emailB) = await Signup(client, "Member", "password123");
+        var (_, _, _, emailC) = await Signup(client, "Invitee C", "password123");
+
+        var groupId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "ById Cancel Auth Group" }, accessA)))["id"]!.GetValue<string>();
+        var memberInviteToken = (await ReadJsonObject(await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailB }, accessA)))["token"]!.GetValue<string>();
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = memberInviteToken }, accessB)).StatusCode);
+
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailC }, accessA)).StatusCode);
+        var listResponse = await Get(client, $"/api/v1/groups/{groupId}/invites", accessA);
+        var invites = await listResponse.Content.ReadFromJsonAsync<JsonArray>(JsonOptions) ?? new JsonArray();
+        var inviteId = invites[0]?["id"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(inviteId));
+
+        var cancel = await Delete(client, $"/api/v1/groups/{groupId}/invites/by-id/{inviteId}", accessB);
+        Assert.Equal(HttpStatusCode.Forbidden, cancel.StatusCode);
+    }
+
+    [Fact]
+    public async Task CancelInviteById_WrongGroupPathReturnsNotFound()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, _, _) = await Signup(client, "Owner", "password123");
+        var (_, _, _, emailC) = await Signup(client, "Invitee C", "password123");
+
+        var groupAId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "Invite Source Group" }, accessA)))["id"]!.GetValue<string>();
+        var groupBId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "Wrong Path Group" }, accessA)))["id"]!.GetValue<string>();
+
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, $"/api/v1/groups/{groupAId}/invites", new { email = emailC }, accessA)).StatusCode);
+        var listResponse = await Get(client, $"/api/v1/groups/{groupAId}/invites", accessA);
+        var invites = await listResponse.Content.ReadFromJsonAsync<JsonArray>(JsonOptions) ?? new JsonArray();
+        var inviteId = invites[0]?["id"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(inviteId));
+
+        var cancel = await Delete(client, $"/api/v1/groups/{groupBId}/invites/by-id/{inviteId}", accessA);
+        Assert.Equal(HttpStatusCode.NotFound, cancel.StatusCode);
+    }
+
+    [Fact]
+    public async Task CancelInviteById_InvalidInviteIdReturnsValidationError()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, _, _) = await Signup(client, "Owner", "password123");
+        var groupId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "Invalid Invite Id Group" }, accessA)))["id"]!.GetValue<string>();
+
+        var cancel = await Delete(client, $"/api/v1/groups/{groupId}/invites/by-id/not-a-uuid", accessA);
+        Assert.Equal(HttpStatusCode.BadRequest, cancel.StatusCode);
+    }
+
+    [Fact]
+    public async Task InviteAcceptance_WorksWhenInviteIsSentByNonOwnerMember()
+    {
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, _, _) = await Signup(client, "Owner", "password123");
+        var (accessB, _, _, emailB) = await Signup(client, "Member", "password123");
+        var (accessC, _, _, emailC) = await Signup(client, "Invitee C", "password123");
+
+        var groupId = (await ReadJsonObject(await PostJson(client, "/api/v1/groups", new { name = "Member Sent Invite Group" }, accessA)))["id"]!.GetValue<string>();
+        var memberInviteToken = (await ReadJsonObject(await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailB }, accessA)))["token"]!.GetValue<string>();
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = memberInviteToken }, accessB)).StatusCode);
+
+        var inviteFromMember = await PostJson(client, $"/api/v1/groups/{groupId}/invites", new { email = emailC }, accessB);
+        Assert.Equal(HttpStatusCode.OK, inviteFromMember.StatusCode);
+        var inviteToken = (await ReadJsonObject(inviteFromMember))["token"]!.GetValue<string>();
+
+        var accept = await PostJson(client, "/api/v1/invites/accept", new { token = inviteToken }, accessC);
+        Assert.Equal(HttpStatusCode.OK, accept.StatusCode);
+
+        var detailsAsInvitee = await Get(client, $"/api/v1/groups/{groupId}/details", accessC);
+        Assert.Equal(HttpStatusCode.OK, detailsAsInvitee.StatusCode);
+    }
+
+    [Fact]
     public async Task MemberCanCreateExpenseOnBehalfOfAnotherMember_CurrentBehavior()
     {
         using var factory = new CustomWebApplicationFactory();

--- a/tests/MambaSplit.Api.Tests/Integration/ScenarioHtmlReportIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/ScenarioHtmlReportIntegrationTests.cs
@@ -66,37 +66,64 @@ public class ScenarioHtmlReportIntegrationTests
         }
         scenarioEvents.Add("Created 10 equal-split expenses in Group B.");
 
-        var detailsA = await GetGroupDetails(client, groupA, users[0].AccessToken);
-        var detailsB = await GetGroupDetails(client, groupB, users[1].AccessToken);
-        var expenseRowsA = detailsA["expenses"]?.AsArray() ?? [];
-        var expenseRowsB = detailsB["expenses"]?.AsArray() ?? [];
-        var expenseIdsA = expenseRowsA
-            .Select(e => e?["id"]?.GetValue<string>() ?? string.Empty)
-            .Where(id => id.Length > 0)
-            .ToList();
-        var expenseIdsB = expenseRowsB
-            .Select(e => e?["id"]?.GetValue<string>() ?? string.Empty)
-            .Where(id => id.Length > 0)
-            .ToList();
-        var settlementAmountA = expenseRowsA.Sum(e => e?["amountCents"]?.GetValue<long>() ?? 0L);
-        var settlementAmountB = expenseRowsB.Sum(e => e?["amountCents"]?.GetValue<long>() ?? 0L);
+        var gaSettleExpenseId = await CreateEqualExpenseAndGetId(
+            client,
+            groupA,
+            users[0].AccessToken,
+            users[0].UserId,
+            1000,
+            new[] { users[0].UserId, users[3].UserId },
+            "GA settle pair");
+        _ = await CreateSettlement(
+            client,
+            groupA,
+            users[3].AccessToken,
+            users[3].UserId,
+            users[0].UserId,
+            500,
+            new List<string> { gaSettleExpenseId },
+            "GA settle pair");
 
-        _ = await CreateSettlement(client, groupA, users[3].AccessToken, users[3].UserId, users[0].UserId, settlementAmountA, expenseIdsA, "GA settle all");
-        _ = await CreateSettlement(client, groupB, users[6].AccessToken, users[6].UserId, users[1].UserId, settlementAmountB, expenseIdsB, "GB settle all");
-        scenarioEvents.Add("Created full-coverage settlements for both groups (amount equals sum of selected expenses).");
+        var gbSettleExpenseId = await CreateEqualExpenseAndGetId(
+            client,
+            groupB,
+            users[1].AccessToken,
+            users[1].UserId,
+            1200,
+            new[] { users[1].UserId, users[6].UserId },
+            "GB settle pair");
+        _ = await CreateSettlement(
+            client,
+            groupB,
+            users[6].AccessToken,
+            users[6].UserId,
+            users[1].UserId,
+            600,
+            new List<string> { gbSettleExpenseId },
+            "GB settle pair");
+        scenarioEvents.Add("Created deterministic pair settlements for both groups.");
 
         var resetResponse = await AdminResetGroupSettlements(client, groupA, users[0].AccessToken);
         scenarioEvents.Add($"Admin reset settlements for Group A (deleted={resetResponse.deletedSettlementCount}, releasedExpenses={resetResponse.releasedExpenseCount}).");
 
-        var detailsAfterResetA = await GetGroupDetails(client, groupA, users[0].AccessToken);
-        var expenseRowsAfterResetA = detailsAfterResetA["expenses"]?.AsArray() ?? [];
-        var expenseIdsAfterResetA = expenseRowsAfterResetA
-            .Select(e => e?["id"]?.GetValue<string>() ?? string.Empty)
-            .Where(id => id.Length > 0)
-            .ToList();
-        var settlementAmountAfterResetA = expenseRowsAfterResetA.Sum(e => e?["amountCents"]?.GetValue<long>() ?? 0L);
-        _ = await CreateSettlement(client, groupA, users[4].AccessToken, users[4].UserId, users[2].UserId, settlementAmountAfterResetA, expenseIdsAfterResetA, "GA re-settle all");
-        scenarioEvents.Add("Re-settled all Group A expenses after admin reset.");
+        var gaResettleExpenseId = await CreateEqualExpenseAndGetId(
+            client,
+            groupA,
+            users[2].AccessToken,
+            users[2].UserId,
+            1400,
+            new[] { users[2].UserId, users[4].UserId },
+            "GA re-settle pair");
+        _ = await CreateSettlement(
+            client,
+            groupA,
+            users[4].AccessToken,
+            users[4].UserId,
+            users[2].UserId,
+            700,
+            new List<string> { gaResettleExpenseId },
+            "GA re-settle pair");
+        scenarioEvents.Add("Re-settled Group A using a deterministic pair settlement after admin reset.");
 
         var outputPath = Path.Combine(
             FindRepositoryRoot(),
@@ -269,6 +296,13 @@ public class ScenarioHtmlReportIntegrationTests
     {
         var response = await PostJson(client, $"/api/v1/groups/{groupId}/expenses/equal", new { description, payerUserId, amountCents, participants }, bearer);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private static async Task<string> CreateEqualExpenseAndGetId(HttpClient client, string groupId, string bearer, string payerUserId, long amountCents, string[] participants, string description)
+    {
+        var response = await PostJson(client, $"/api/v1/groups/{groupId}/expenses/equal", new { description, payerUserId, amountCents, participants }, bearer);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return (await ReadJsonObject(response))["expenseId"]!.GetValue<string>();
     }
 
     private static async Task CreateExactExpense(HttpClient client, string groupId, string bearer, string payerUserId, long amountCents, object[] items, string description)

--- a/tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
@@ -66,7 +66,7 @@ public class SettlementIntegrityIntegrationTests
         {
             fromUserId = userIdB,
             toUserId = userIdA,
-            amountCents = 5000L,
+            amountCents = 2500L,
             expenseIds = new[] { expenseId },
             note = "settle dinner",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
@@ -135,7 +135,7 @@ public class SettlementIntegrityIntegrationTests
     }
 
     [Fact]
-    public async Task CreateSettlement_WithoutExpenseIds_AllowsCashSettlement()
+    public async Task CreateSettlement_WithoutExpenseIds_ReturnsValidationFailed()
     {
         using var factory = new CustomWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -167,14 +167,10 @@ public class SettlementIntegrityIntegrationTests
             note = "cash settle partial",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessA);
-        Assert.Equal(HttpStatusCode.Created, createSettlement.StatusCode);
-        var settlementId = (await ReadJsonObject(createSettlement))["settlementId"]!.GetValue<string>();
-
-        var settlementDetails = await Get(client, $"/api/v1/settlements/{settlementId}", accessA);
-        Assert.Equal(HttpStatusCode.OK, settlementDetails.StatusCode);
-        var detailsPayload = await ReadJsonObject(settlementDetails);
-        var linkedExpenses = detailsPayload["expenseIds"]?.AsArray().ToList() ?? [];
-        Assert.Empty(linkedExpenses);
+        Assert.Equal(HttpStatusCode.BadRequest, createSettlement.StatusCode);
+        var payload = await ReadJsonObject(createSettlement);
+        Assert.Equal("VALIDATION_FAILED", payload["code"]?.GetValue<string>());
+        Assert.Equal("At least one expense must be selected", payload["message"]?.GetValue<string>());
     }
 
     [Fact]
@@ -206,7 +202,7 @@ public class SettlementIntegrityIntegrationTests
         {
             fromUserId = userIdB,
             toUserId = userIdA,
-            amountCents = 5000L,
+            amountCents = 2500L,
             expenseIds = new[] { expenseId },
             note = "settle dinner",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),


### PR DESCRIPTION
## Summary
Implemented invite sender ownership enforcement, settlement-expense integrity validation, and aligned integration test configuration/scenario flow.

## Files/Modules Affected
- src/MambaSplit.Api/Controllers/GroupController.cs
- src/MambaSplit.Api/Data/AppDbContext.cs
- src/MambaSplit.Api/Domain/InviteEntity.cs
- src/MambaSplit.Api/Services/GroupService.cs
- src/MambaSplit.Api/Services/SettlementService.cs
- src/MambaSplit.Api/Database/Migrations/V6__invite_sender_ownership.sql
- src/MambaSplit.Api/Database/Migrations/V7__enforce_settlement_expense_link.sql
- src/MambaSplit.Api/appsettings.Test.json
- tests/MambaSplit.Api.Tests/Integration/FlowIntegrationTests.cs
- tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
- tests/MambaSplit.Api.Tests/Integration/ScenarioHtmlReportIntegrationTests.cs

## Test/Validation Results
- dotnet test
- Passed: 38
- Failed: 0

Closes #6