### PR TITLE
chore: merge develop into main — friend connections API, settlement fixes, and test coverage

### DIFF
--- a/.github/agents/feature-workflow-manager.agent.md
+++ b/.github/agents/feature-workflow-manager.agent.md
@@ -1,14 +1,14 @@
 ﻿---
 name: feature-workflow-manager
-description: "Use when: feature_start, feature_commit, feature_finalize, full feature branch workflow from issue to PR."
+description: "Use when: feature_start, feature_commit, feature_finalize, prepare_release, full feature branch workflow from issue to release PR."
 tools: [execute, read, search, web]
-argument-hint: "Workflow action and context, for example: feature_start 21, feature_commit, or feature_finalize [next-issue-number]"
+argument-hint: "Workflow action and context, for example: feature_start 21, feature_commit, feature_finalize [next-issue-number], or prepare_release"
 user-invocable: true
 ---
 You automate end-to-end feature workflow lifecycle operations.
 
 ## Responsibilities
-1. Determine whether the user requested start, commit-sync, or finalize flow.
+1. Determine whether the user requested start, commit-sync, finalize, or release-preparation flow.
 2. For feature_start:
 - validate issue number is numeric,
 - fetch issue title and labels,
@@ -34,6 +34,14 @@ You automate end-to-end feature workflow lifecycle operations.
 - poll gh pr view --json statusCheckRollup until all CI checks complete; if any check fails, stop and report the failing check name and log URL — do not mark finalize done until all checks pass,
 - report PR link and concise change summary,
 - if next issue number is provided, chain into start flow.
+5. For prepare_release:
+- create or update the release PR from `develop` to `main`,
+- update the PR title to something meaningful and make sure it follows repository convention so CI or title validation does not fail,
+- review the full `develop` to `main` diff so the PR body reflects the entire release scope,
+- update the PR body with `Motivation`, `What changed`, `Testing done`, `Risks/regressions`, `Migration notes` (if any), and a short checklist,
+- make the checklist concrete and accurate for the release, for example: `Refs #<issue-number>` when applicable, `Targets: main`, and `Tests: unit/integration/e2e` based on what was actually validated,
+- add a `---` divider after the engineering-facing sections,
+- append a concise end-user-facing release highlights section written in plain language for release publicity.
 
 ## Guardrails
 - Do not push directly to develop or main.

--- a/.github/prompts/git-actions.prompt.md
+++ b/.github/prompts/git-actions.prompt.md
@@ -1,4 +1,11 @@
-﻿Use when: you need a standardized, policy-compliant git artifact (branch name, commit message, PR title/body) or a risk-first review of a PR/diff.
+﻿---
+name: git-actions
+description: "Workspace prompt for generating and reviewing all git branch/commit/PR actions. Uses the `risk-first-pr-reviewer` agent to prioritize risk and correctness."
+agent: feature-workflow-manager
+model: GPT-4.1 (copilot)
+---
+
+Use when: you need a standardized, policy-compliant git artifact (branch name, commit message, PR title/body) or a risk-first review of a PR/diff.
 
 Guidelines:
 - Apply the workspace branch naming guardrails:
@@ -26,10 +33,8 @@ Prompts / Examples:
 
 - Risk-first PR review:
   - Input: `action: review_detailed`, `context: { pr_link or diff }`
-  - Output: prioritized findings (Critical -> High -> Medium -> Low), clear reproduction or code pointers, suggested fixes, and whether the PR should be merged to `develop` or requires changes.
+  - Output: prioritized findings (Critical → High → Medium → Low), clear reproduction or code pointers, suggested fixes, and whether the PR should be merged to `develop` or requires changes.
 
 Notes and enforcement:
 - When generating branch/commit/PR artifacts, validate and correct names to match the guardrails. If an input cannot be transformed to a compliant value, return a short explanation and a suggested compliant alternative.
 - Keep outputs concise and machine-friendly where possible (one-line branch name, JSON-like metadata for automation).
-
-This prompt uses a hybrid mapping by default: `gpt-5-mini` for routine artifacts and `gpt-4.1` for `review_*` actions. If you would like to change the default model or mapping, tell me and I will update the prompt.

--- a/MambaSplit.Api.code-workspace
+++ b/MambaSplit.Api.code-workspace
@@ -5,6 +5,7 @@
     }
   ],
   "settings": {
-    "window.title": "${rootName}"
+    "window.title": "${rootName}",
+    "workbench.colorTheme": "Abyss"
   }
 }

--- a/src/MambaSplit.Api/Controllers/SettlementsController.cs
+++ b/src/MambaSplit.Api/Controllers/SettlementsController.cs
@@ -36,9 +36,6 @@ public class SettlementsController : ControllerBase
             fromUserId,
             toUserId,
             request.AmountCents,
-            request.ExpenseIds
-                .Select(x => ParseGuid(x, "expenseIds"))
-                .ToList(),
             request.Note,
             settledAt,
             ct);
@@ -114,7 +111,6 @@ public record CreateSettlementRequest(
     [Required, NotBlank] string FromUserId,
     [Required, NotBlank] string ToUserId,
     [Range(1, long.MaxValue)] long AmountCents,
-    [Required, MinLength(1)] List<string> ExpenseIds,
     [MaxLength(500)] string? Note,
     string? SettledAt);
 

--- a/src/MambaSplit.Api/Services/GroupService.cs
+++ b/src/MambaSplit.Api/Services/GroupService.cs
@@ -92,7 +92,6 @@ public class GroupService
             .ToListAsync(ct);
         var recentGroupExpenses = allGroupExpenses
             .OrderByDescending(e => e.CreatedAt)
-            .Take(50)
             .ToList();
         var allExpenseIds = allGroupExpenses.Select(e => e.Id).ToList();
         var settlementExpenseLinks = allExpenseIds.Count == 0
@@ -114,7 +113,6 @@ public class GroupService
             .ToListAsync(ct);
         var recentGroupSettlements = allGroupSettlements
             .OrderByDescending(s => s.CreatedAt)
-            .Take(50)
             .ToList();
 
         var splitRows = allExpenseIds.Count == 0

--- a/src/MambaSplit.Api/Services/SettlementService.cs
+++ b/src/MambaSplit.Api/Services/SettlementService.cs
@@ -375,7 +375,7 @@ public class SettlementService
                 .ToListAsync(ct);
 
             var recipientEmails = await _db.Users
-                .Where(u => memberUserIds.Contains(u.Id) && u.Id != actorUserId && !string.IsNullOrWhiteSpace(u.Email))
+                .Where(u => memberUserIds.Contains(u.Id) && !string.IsNullOrWhiteSpace(u.Email))
                 .Select(u => u.Email)
                 .ToListAsync(ct);
 

--- a/src/MambaSplit.Api/Services/SettlementService.cs
+++ b/src/MambaSplit.Api/Services/SettlementService.cs
@@ -33,15 +33,10 @@ public class SettlementService
         Guid fromUserId,
         Guid toUserId,
         long amountCents,
-        List<Guid> expenseIds,
         string? note = null,
         DateTimeOffset? settledAt = null,
         CancellationToken ct = default)
     {
-        var normalizedExpenseIds = expenseIds
-            .Where(id => id != Guid.Empty)
-            .ToList();
-
         if (amountCents <= 0)
         {
             throw new ValidationException("Amount must be greater than 0");
@@ -57,16 +52,6 @@ public class SettlementService
             throw new ValidationException("Settlement note cannot exceed 500 characters");
         }
 
-        if (normalizedExpenseIds.Distinct().Count() != normalizedExpenseIds.Count)
-        {
-            throw new ValidationException("Duplicate expense ids in settlement payload");
-        }
-
-        if (normalizedExpenseIds.Count == 0)
-        {
-            throw new ValidationException("At least one expense must be selected");
-        }
-
         await _groupService.RequireMemberAsync(groupId, actorUserId, ct);
         await _groupService.RequireMembersAsync(groupId, new[] { fromUserId, toUserId }, ct);
 
@@ -78,6 +63,83 @@ public class SettlementService
         if (effectiveSettledAt > now.AddMinutes(5))
         {
             throw new ValidationException("Settlement date cannot be in the future");
+        }
+
+        // Auto-select all unsettled expenses that are pair-relevant:
+        // expenses paid by toUserId where fromUserId has a split (fromUser owes toUser),
+        // and expenses paid by fromUserId where toUserId has a split (netted off in the opposite direction).
+        var alreadyLinkedList = await _db.SettlementExpenses
+            .Select(se => se.ExpenseId)
+            .Distinct()
+            .ToListAsync(ct);
+        var alreadyLinkedExpenseIds = alreadyLinkedList.ToHashSet();
+
+        var candidateExpenses = await _db.Expenses
+            .Where(e => e.GroupId == groupId
+                && !alreadyLinkedExpenseIds.Contains(e.Id)
+                && (e.PayerUserId == toUserId || e.PayerUserId == fromUserId))
+            .Select(e => new { e.Id, e.PayerUserId })
+            .ToListAsync(ct);
+
+        var candidateIds = candidateExpenses.Select(e => e.Id).ToHashSet();
+        var splits = await _db.ExpenseSplits
+            .Where(s => candidateIds.Contains(s.ExpenseId) && (s.UserId == fromUserId || s.UserId == toUserId))
+            .Select(s => new { s.ExpenseId, s.UserId, s.AmountOwedCents })
+            .ToListAsync(ct);
+
+        var splitsByExpense = splits
+            .GroupBy(s => s.ExpenseId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Only include expenses that actually have a non-zero split for this pair.
+        var pairExpenses = candidateExpenses
+            .Where(e =>
+            {
+                var expSplits = splitsByExpense.GetValueOrDefault(e.Id, []);
+                if (e.PayerUserId == toUserId)
+                    return expSplits.Any(s => s.UserId == fromUserId && s.AmountOwedCents > 0);
+                if (e.PayerUserId == fromUserId)
+                    return expSplits.Any(s => s.UserId == toUserId && s.AmountOwedCents > 0);
+                return false;
+            })
+            .ToList();
+
+        long expectedAmountCents = 0;
+        try
+        {
+            foreach (var expense in pairExpenses)
+            {
+                var expenseSplits = splitsByExpense.GetValueOrDefault(expense.Id, []);
+                if (expense.PayerUserId == toUserId)
+                {
+                    var fromOwed = expenseSplits
+                        .Where(s => s.UserId == fromUserId)
+                        .Sum(s => s.AmountOwedCents);
+                    expectedAmountCents = checked(expectedAmountCents + fromOwed);
+                }
+
+                if (expense.PayerUserId == fromUserId)
+                {
+                    var toOwed = expenseSplits
+                        .Where(s => s.UserId == toUserId)
+                        .Sum(s => s.AmountOwedCents);
+                    expectedAmountCents = checked(expectedAmountCents - toOwed);
+                }
+            }
+        }
+        catch (OverflowException)
+        {
+            throw new ValidationException("Settlement amount calculation overflow");
+        }
+
+        if (expectedAmountCents <= 0)
+        {
+            throw new ValidationException("No outstanding balance exists for this pair");
+        }
+
+        if (expectedAmountCents != amountCents)
+        {
+            throw new ValidationException($"Settlement amount ({amountCents}) does not match outstanding pair balance ({expectedAmountCents})");
         }
 
         var settlement = new SettlementEntity
@@ -93,83 +155,14 @@ public class SettlementService
 
         _db.Settlements.Add(settlement);
 
-        if (normalizedExpenseIds.Count > 0)
+        foreach (var expense in pairExpenses)
         {
-            var expenses = await _db.Expenses
-                .Where(e => e.GroupId == groupId && normalizedExpenseIds.Contains(e.Id))
-                .Select(e => new { e.Id, e.PayerUserId })
-                .ToListAsync(ct);
-            if (expenses.Count != normalizedExpenseIds.Count)
+            _db.SettlementExpenses.Add(new SettlementExpenseEntity
             {
-                throw new ValidationException("One or more expenses do not belong to this group");
-            }
-
-            var expenseIdsSet = normalizedExpenseIds.ToHashSet();
-            var splits = await _db.ExpenseSplits
-                .Where(s => expenseIdsSet.Contains(s.ExpenseId) && (s.UserId == fromUserId || s.UserId == toUserId))
-                .Select(s => new { s.ExpenseId, s.UserId, s.AmountOwedCents })
-                .ToListAsync(ct);
-            var splitsByExpense = splits
-                .GroupBy(s => s.ExpenseId)
-                .ToDictionary(g => g.Key, g => g.ToList());
-
-            long expectedAmountCents = 0;
-            try
-            {
-                foreach (var expense in expenses)
-                {
-                    var expenseSplits = splitsByExpense.GetValueOrDefault(expense.Id, []);
-                    if (expense.PayerUserId == toUserId)
-                    {
-                        var fromOwed = expenseSplits
-                            .Where(s => s.UserId == fromUserId)
-                            .Sum(s => s.AmountOwedCents);
-                        expectedAmountCents = checked(expectedAmountCents + fromOwed);
-                    }
-
-                    if (expense.PayerUserId == fromUserId)
-                    {
-                        var toOwed = expenseSplits
-                            .Where(s => s.UserId == toUserId)
-                            .Sum(s => s.AmountOwedCents);
-                        expectedAmountCents = checked(expectedAmountCents - toOwed);
-                    }
-                }
-            }
-            catch (OverflowException)
-            {
-                throw new ValidationException("Settlement amount calculation overflow");
-            }
-
-            if (expectedAmountCents <= 0)
-            {
-                throw new ValidationException("Selected expenses do not produce an outstanding balance for the selected payer and receiver");
-            }
-
-            if (expectedAmountCents != amountCents)
-            {
-                throw new ValidationException($"Settlement amount ({amountCents}) must match selected outstanding balance ({expectedAmountCents})");
-            }
-
-            var alreadySettled = await _db.SettlementExpenses
-                .Where(se => normalizedExpenseIds.Contains(se.ExpenseId))
-                .Select(se => se.ExpenseId)
-                .Distinct()
-                .ToListAsync(ct);
-            if (alreadySettled.Count > 0)
-            {
-                throw new ConflictException("One or more expenses are already associated with a settlement");
-            }
-
-            foreach (var expenseId in normalizedExpenseIds)
-            {
-                _db.SettlementExpenses.Add(new SettlementExpenseEntity
-                {
-                    Id = Guid.NewGuid(),
-                    SettlementId = settlement.Id,
-                    ExpenseId = expenseId,
-                });
-            }
+                Id = Guid.NewGuid(),
+                SettlementId = settlement.Id,
+                ExpenseId = expense.Id,
+            });
         }
 
         try

--- a/tests/MambaSplit.Api.Tests/Integration/FlowIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/FlowIntegrationTests.cs
@@ -636,7 +636,7 @@ public class FlowIntegrationTests
         Assert.Equal(5100L, detailsA["summary"]?["totalExpenseAmountCents"]?.GetValue<long>());
         Assert.Equal(2550L, detailsA["me"]?["netBalanceCents"]?.GetValue<long>());
         Assert.Equal(-2550L, detailsB["me"]?["netBalanceCents"]?.GetValue<long>());
-        Assert.Equal(50, detailsA["expenses"]?.AsArray().Count);
+        Assert.Equal(51, detailsA["expenses"]?.AsArray().Count);
     }
 
     [Fact]

--- a/tests/MambaSplit.Api.Tests/Integration/ScenarioHtmlReportIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/ScenarioHtmlReportIntegrationTests.cs
@@ -313,7 +313,36 @@ public class ScenarioHtmlReportIntegrationTests
 
     private static async Task<string> CreateSettlement(HttpClient client, string groupId, string bearer, string fromUserId, string toUserId, long amountCents, List<string> expenseIds, string note)
     {
-        var response = await PostJson(client, $"/api/v1/groups/{groupId}/settlements", new { fromUserId, toUserId, amountCents, expenseIds, note, settledAt = DateTimeOffset.UtcNow.ToString("O") }, bearer);
+        // Backend auto-selects all unsettled pair expenses and validates amountCents against the
+        // computed net balance. Compute that same balance from group details so the value matches.
+        var detailsResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, $"/api/v1/groups/{groupId}/details")
+        {
+            Headers = { Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearer) },
+        });
+        var details = await ReadJsonObject(detailsResponse);
+
+        long pairBalance = 0;
+        foreach (var expense in details["expenses"]?.AsArray() ?? new System.Text.Json.Nodes.JsonArray())
+        {
+            if (expense?["settlementId"] != null) continue;
+            var payerUserId = expense?["payerUserId"]?.GetValue<string>();
+            var splits = expense?["splits"]?.AsArray() ?? new System.Text.Json.Nodes.JsonArray();
+            if (payerUserId == toUserId)
+            {
+                pairBalance += splits
+                    .Where(s => s?["userId"]?.GetValue<string>() == fromUserId)
+                    .Sum(s => s?["amountOwedCents"]?.GetValue<long>() ?? 0L);
+            }
+            else if (payerUserId == fromUserId)
+            {
+                pairBalance -= splits
+                    .Where(s => s?["userId"]?.GetValue<string>() == toUserId)
+                    .Sum(s => s?["amountOwedCents"]?.GetValue<long>() ?? 0L);
+            }
+        }
+
+        var resolvedAmount = pairBalance > 0 ? pairBalance : amountCents;
+        var response = await PostJson(client, $"/api/v1/groups/{groupId}/settlements", new { fromUserId, toUserId, amountCents = resolvedAmount, note, settledAt = DateTimeOffset.UtcNow.ToString("O") }, bearer);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         return (await ReadJsonObject(response))["settlementId"]!.GetValue<string>();
     }

--- a/tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
@@ -149,10 +149,9 @@ public class SettlementIntegrityIntegrationTests
 
         var message = sentMessages[0];
         var actualRecipients = message.To.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
-        var expectedRecipients = new[] { emailA, emailC }.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
+        var expectedRecipients = new[] { emailA, emailB, emailC }.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
 
         Assert.Equal(expectedRecipients, actualRecipients);
-        Assert.DoesNotContain(message.To, recipient => string.Equals(recipient, emailB, StringComparison.OrdinalIgnoreCase));
         Assert.Contains("Settlement recorded in Settlement Email Group", message.Subject);
         Assert.Contains("$30.00", message.HtmlBody);
         Assert.Contains($"https://app.mambasplit.test?groupId={groupId}", message.HtmlBody);

--- a/tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
+++ b/tests/MambaSplit.Api.Tests/Integration/SettlementIntegrityIntegrationTests.cs
@@ -73,7 +73,6 @@ public class SettlementIntegrityIntegrationTests
             fromUserId = userIdB,
             toUserId = userIdA,
             amountCents = 2500L,
-            expenseIds = new[] { expenseId },
             note = "settle dinner",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessB);
@@ -141,7 +140,6 @@ public class SettlementIntegrityIntegrationTests
             fromUserId = userIdB,
             toUserId = userIdA,
             amountCents = 3000L,
-            expenseIds = new[] { expenseId },
             note = "Paid back for dinner",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessB);
@@ -193,7 +191,6 @@ public class SettlementIntegrityIntegrationTests
             fromUserId = userIdB,
             toUserId = userIdA,
             amountCents = 4999L,
-            expenseIds = new[] { expenseId },
             note = "mismatch",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessB);
@@ -203,7 +200,7 @@ public class SettlementIntegrityIntegrationTests
     }
 
     [Fact]
-    public async Task CreateSettlement_WithoutExpenseIds_ReturnsValidationFailed()
+    public async Task CreateSettlement_NoOutstandingBalance_ReturnsValidationFailed()
     {
         using var factory = new CustomWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -212,33 +209,23 @@ public class SettlementIntegrityIntegrationTests
         var (accessA, _, userIdA, _) = await Signup(client, "User A", "password123");
         var (accessB, _, userIdB, emailB) = await Signup(client, "User B", "password123");
 
-        var groupId = await CreateGroup(client, accessA, "Cash Settlement Group");
+        var groupId = await CreateGroup(client, accessA, "No Balance Group");
         var inviteToken = await Invite(client, groupId, accessA, emailB);
         var accept = await PostJson(client, "/api/v1/invites/accept", new { token = inviteToken }, accessB);
         Assert.Equal(HttpStatusCode.OK, accept.StatusCode);
 
-        var createExpense = await PostJson(client, $"/api/v1/groups/{groupId}/expenses/equal", new
-        {
-            description = "Dinner",
-            payerUserId = userIdA,
-            amountCents = 5000L,
-            participants = new[] { userIdA, userIdB },
-        }, accessA);
-        Assert.Equal(HttpStatusCode.OK, createExpense.StatusCode);
-
+        // No expenses created — pair has no outstanding balance.
         var createSettlement = await PostJson(client, $"/api/v1/groups/{groupId}/settlements", new
         {
             fromUserId = userIdB,
             toUserId = userIdA,
-            amountCents = 2500L,
-            expenseIds = Array.Empty<string>(),
-            note = "cash settle partial",
+            amountCents = 1000L,
+            note = "no balance",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessB);
         Assert.Equal(HttpStatusCode.BadRequest, createSettlement.StatusCode);
         var payload = await ReadJsonObject(createSettlement);
         Assert.Equal("VALIDATION_FAILED", payload["code"]?.GetValue<string>());
-        Assert.Contains("ExpenseIds", payload["message"]?.GetValue<string>() ?? string.Empty);
     }
 
     [Fact]
@@ -271,7 +258,6 @@ public class SettlementIntegrityIntegrationTests
             fromUserId = userIdB,
             toUserId = userIdA,
             amountCents = 2500L,
-            expenseIds = new[] { expenseId },
             note = "settle dinner",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessB);
@@ -322,7 +308,6 @@ public class SettlementIntegrityIntegrationTests
             fromUserId = userIdB,
             toUserId = userIdA,
             amountCents = 2500L,
-            expenseIds = new[] { expenseId },
             note = "settle dinner",
             settledAt = DateTimeOffset.UtcNow.ToString("O"),
         }, accessA);
@@ -367,6 +352,133 @@ public class SettlementIntegrityIntegrationTests
 
         var delete = await Delete(client, $"/api/v1/groups/{groupId}/expenses/{expenseId}", accessA);
         Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateSettlement_FourPersonGroup_DoesNotCrossContaminateOtherPairExpenses()
+    {
+        // Regression test for Bug 4: backend must only link pair-relevant expenses.
+        // Alex/Blair settle first. Carol/Dave must still be able to settle afterward.
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (aAccess, _, aId, _) = await Signup(client, "Alex", "password123");
+        var (bAccess, _, bId, bEmail) = await Signup(client, "Blair", "password123");
+        var (cAccess, _, cId, cEmail) = await Signup(client, "Carol", "password123");
+        var (dAccess, _, dId, dEmail) = await Signup(client, "Dave", "password123");
+
+        var gId = await CreateGroup(client, aAccess, "4P Group");
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = await Invite(client, gId, aAccess, bEmail) }, bAccess)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = await Invite(client, gId, aAccess, cEmail) }, cAccess)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = await Invite(client, gId, aAccess, dEmail) }, dAccess)).StatusCode);
+
+        // Alex pays $10 000; Blair/Carol/Dave each owe $2 500.
+        var expAlex = await PostJson(client, $"/api/v1/groups/{gId}/expenses/equal", new
+        {
+            description = "Alex pays",
+            payerUserId = aId,
+            amountCents = 10000L,
+            participants = new[] { aId, bId, cId, dId },
+        }, aAccess);
+        Assert.Equal(HttpStatusCode.OK, expAlex.StatusCode);
+
+        // Carol pays $6 000; Dave owes $3 000.
+        var expCarol = await PostJson(client, $"/api/v1/groups/{gId}/expenses/equal", new
+        {
+            description = "Carol pays",
+            payerUserId = cId,
+            amountCents = 6000L,
+            participants = new[] { cId, dId },
+        }, cAccess);
+        Assert.Equal(HttpStatusCode.OK, expCarol.StatusCode);
+        var carolExpenseId = (await ReadJsonObject(expCarol))["expenseId"]!.GetValue<string>();
+
+        // Blair settles with Alex (Blair owes Alex $2 500).
+        var blairSettle = await PostJson(client, $"/api/v1/groups/{gId}/settlements", new
+        {
+            fromUserId = bId,
+            toUserId = aId,
+            amountCents = 2500L,
+            note = "Blair pays Alex",
+            settledAt = DateTimeOffset.UtcNow.ToString("O"),
+        }, bAccess);
+        Assert.Equal(HttpStatusCode.Created, blairSettle.StatusCode);
+        var blairSettlementId = (await ReadJsonObject(blairSettle))["settlementId"]!.GetValue<string>();
+
+        // Verify Carol/Dave's expense is NOT linked to Blair's settlement.
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var linkedToBlairSettlement = await db.SettlementExpenses
+                .AsNoTracking()
+                .Where(se => se.SettlementId == Guid.Parse(blairSettlementId))
+                .Select(se => se.ExpenseId.ToString())
+                .ToListAsync();
+            Assert.DoesNotContain(carolExpenseId, linkedToBlairSettlement);
+        }
+
+        // Dave can now settle with Carol without CONFLICT (Bug 4 would have locked carolExpenseId).
+        var daveSettle = await PostJson(client, $"/api/v1/groups/{gId}/settlements", new
+        {
+            fromUserId = dId,
+            toUserId = cId,
+            amountCents = 3000L,
+            note = "Dave pays Carol",
+            settledAt = DateTimeOffset.UtcNow.ToString("O"),
+        }, dAccess);
+        Assert.Equal(HttpStatusCode.Created, daveSettle.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateSettlement_ManyExpenses_AutoSelectsAllAndSucceeds()
+    {
+        // Regression: backend must auto-select ALL unsettled pair expenses, not just
+        // a capped subset (e.g. the 50-expense window the old client used).
+        using var factory = new CustomWebApplicationFactory();
+        using var client = factory.CreateClient();
+        await EnsureDatabaseCreated(factory);
+
+        var (accessA, _, userIdA, _) = await Signup(client, "User A", "password123");
+        var (accessB, _, userIdB, emailB) = await Signup(client, "User B", "password123");
+
+        var groupId = await CreateGroup(client, accessA, "Many Expenses Group");
+        var inviteToken = await Invite(client, groupId, accessA, emailB);
+        Assert.Equal(HttpStatusCode.OK, (await PostJson(client, "/api/v1/invites/accept", new { token = inviteToken }, accessB)).StatusCode);
+
+        // Create 55 expenses so the old 50-expense client window would miss 5.
+        long totalOwedCents = 0;
+        for (var i = 0; i < 55; i++)
+        {
+            var exp = await PostJson(client, $"/api/v1/groups/{groupId}/expenses/equal", new
+            {
+                description = $"Expense {i + 1}",
+                payerUserId = userIdA,
+                amountCents = 1000L,
+                participants = new[] { userIdA, userIdB },
+            }, accessA);
+            Assert.Equal(HttpStatusCode.OK, exp.StatusCode);
+            totalOwedCents += 500L; // userB owes half
+        }
+
+        // Backend auto-selects all 55 expenses; amount = 55 * 500 = 27 500.
+        var settle = await PostJson(client, $"/api/v1/groups/{groupId}/settlements", new
+        {
+            fromUserId = userIdB,
+            toUserId = userIdA,
+            amountCents = totalOwedCents,
+            note = "settle all",
+            settledAt = DateTimeOffset.UtcNow.ToString("O"),
+        }, accessB);
+        Assert.Equal(HttpStatusCode.Created, settle.StatusCode);
+
+        var settlementId = (await ReadJsonObject(settle))["settlementId"]!.GetValue<string>();
+        await using var scope = factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var linkedCount = await db.SettlementExpenses
+            .AsNoTracking()
+            .CountAsync(se => se.SettlementId == Guid.Parse(settlementId));
+        Assert.Equal(55, linkedCount);
     }
 
     private sealed class SettlementEmailTestFactory : WebApplicationFactory<Program>


### PR DESCRIPTION
## Motivation

Promote all backend changes from develop to main for the next production release. This includes the new friend connections API, settlement auto-select fixes, expanded test coverage, and agent sync updates.

## What Changed

- **Friend connections API** — new endpoints, domain, and migrations (Refs #23)
- **Settlement fixes** — auto-select pair expenses, actor in email recipients, remove Take(50) cap (Refs #26)
- **Test coverage** — new and updated tests for friend and settlement flows
- **Agent sync and CI** — require CI success for feature_finalize, Postgres service for tests

## Testing Done

- All backend tests passing (dotnet test)
- CI green on develop

## Risks / Regressions

- New friend connections API — verify integration with frontend and group rollup
- Settlement logic changes — validate with real group data

## Migration Notes

- Run DB migration V8__friend_connections.sql before deploying

## Checklist

- [x] Targets: main (source: develop)
- [x] Refs #23, #26
- [x] Tests: unit/integration (dotnet)
- [x] Lint: clean
- [x] No direct push to main — PR only

---
**Release highlights:**
- Friend connections API
- Settlement auto-select fixes
- Expanded backend test coverage
- Agent sync and CI improvements
